### PR TITLE
Fix emit with opts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ module.exports = {
       const name = event.join('.')
 
       this.broker.emit(`${this.$queueName()}.${name}`, params, emitOpts)
-      this.broker.emit(name, params, this.$queueName(), { ...emitOpts, groups: this.$queueName() })
+      this.broker.emit(name, params, { ...emitOpts, groups: this.$queueName() })
     }
   }
 }


### PR DESCRIPTION
Please, check if this is correct.
`context.emit` has only 3 parameters
(actionName, params, opts)
This line is ignoring emitOpts.

Thanks